### PR TITLE
ci: use pat instead of github token for release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           command: manifest
           default-branch: master
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
       - id: checkout
         uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Using the GITHUB_TOKEN prevents actions from running on release please prs.