### PR TITLE
ci(dependabot): set schedule time to 09:00

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     # Check the npm registry for updates every week
     schedule:     
       interval: "daily"
-      time: "9:00"
+      time: "09:00"
       timezone: "Europe/Berlin"
 
   - package-ecosystem: "github-actions"
@@ -21,5 +21,5 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "daily"
-      time: "9:00"
+      time: "09:00"
       timezone: "Europe/Berlin"


### PR DESCRIPTION
fixes
```
The property '#/updates/0/schedule/time' value "9:00" did not match the
regex '^\d\d:\d\d$'
```