### PR TITLE
ci(dependabot): use `fix` commits for prod dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
       interval: 'daily'
       time: '09:00'
       timezone: 'Europe/Berlin'
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
This will cause a release to be created for prod dependency upgrades