### PR TITLE
feat!: rework cli to use subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Creates feature branches based on your Jira tickets type and description.
 
 ```bash
-$ git create-jira-branch MYAPP-1234
+$ git create-jira-branch create MYAPP-1234
 > Successfully created branch: 'feat/MYAPP-1234-sluggified-description-used-as-branchname'
 ```
 
@@ -30,7 +30,7 @@ before the jira ticket key argument.
 Using the default JIRA_KEY_PREFIX
 
 ```bash
-git-create-jira-branch 1324
+git-create-jira-branch create 1324
 ```
 
 Or fully specified:
@@ -44,7 +44,7 @@ git-create-jira-branch MYAPP-1234
 To create a new branch based on your `master` branch:
 
 ```bash
-git-create-jira-branch -b master MYAPP-1234
+git-create-jira-branch create -b master MYAPP-1234
 ```
 
 ### Reset an already existing branch
@@ -53,19 +53,19 @@ Pass the `-r|--reset` flag to reset an already existing branch to the current
 `HEAD` or the specified base revision (with `-b`)
 
 ```bash
-git-create-jira-branch -r MYAPP-1234
+git-create-jira-branch create -r MYAPP-1234
 ```
 
 ### Open tickets in your browser
 
 1. For the current branch:
    ```bash
-   $ git create-jira-branch --open
+   $ git create-jira-branch open
    > Opening ticket url 'https://gcjb.atlassian.net/browse/GCJB-164' in your default browser...
    ```
 2. For a given ticket:
    ```bash
-   $ git create-jira-branch --open GCJB-1234
+   $ git create-jira-branch open GCJB-1234
    > Opening ticket url 'https://gcjb.atlassian.net/browse/GCJB-1234' in your default browser...
    ```
 

--- a/e2e-test/git-create-jira-branch.spec.ts
+++ b/e2e-test/git-create-jira-branch.spec.ts
@@ -42,13 +42,13 @@ describe('git-create-jira-branch', () => {
     tmpDir = await setupTmpDir();
   });
 
-  it('app starts and outputs help', async () => {
+  it('starts app and outputs help', async () => {
     const res = runApp(tmpDir, '--help');
     expect(res).toMatch(/git-create-jira-branch/);
   });
 
-  it('print error for non existing jira ticket', () => {
-    const res = runApp(tmpDir, 'NOPROJECT-1');
+  it('create subcommand prints error for non existing jira ticket', () => {
+    const res = runApp(tmpDir, 'create', 'NOPROJECT-1');
 
     expect(res).toMatchInlineSnapshot(`
       "[0;31mJira returned status 404. Make sure the ticket with id NOPROJECT-1 exists.[0m
@@ -57,8 +57,8 @@ describe('git-create-jira-branch', () => {
     `);
   });
 
-  it('creates new branch for existing jira ticket', () => {
-    const res = runApp(tmpDir, 'GCJB-1');
+  it('create subcommand creates new branch for existing jira ticket', () => {
+    const res = runApp(tmpDir, 'create', 'GCJB-1');
 
     expect(res).toMatchInlineSnapshot(`
       "Successfully created branch: 'feat/GCJB-1-e2e-test-ticket-with-a-fancy-summary'
@@ -70,8 +70,8 @@ describe('git-create-jira-branch', () => {
     );
   });
 
-  it('switches to already existing branch for existing jira ticket', async () => {
-    const res = runApp(tmpDir, 'GCJB-1');
+  it('create subcommand switches to already existing branch for existing jira ticket', async () => {
+    const res = runApp(tmpDir, 'create', 'GCJB-1');
 
     expect(res).toMatchInlineSnapshot(`
       "Switched to already existing branch: 'feat/GCJB-1-e2e-test-ticket-with-a-fancy-summary'
@@ -82,7 +82,7 @@ describe('git-create-jira-branch', () => {
     );
   });
 
-  it('resets branch to given base ref', () => {
+  it('create subcommand resets branch to given base ref', () => {
     runApp(tmpDir, 'GCJB-1');
     expect(currentBranch(tmpDir)).toMatchInlineSnapshot(
       '"feat/GCJB-1-e2e-test-ticket-with-a-fancy-summary"',
@@ -96,10 +96,10 @@ describe('git-create-jira-branch', () => {
       .trim();
     expect(lastCommitMsg).toMatchInlineSnapshot('"add testFile"');
 
-    runApp(tmpDir, '--reset', 'GCJB-1');
+    runApp(tmpDir, 'create', '--reset', '-b', 'master', 'GCJB-1');
     const lastCommitMsg2 = execSync('git log -1 --pretty=%B', {cwd: tmpDir})
       .toString()
       .trim();
-    expect(lastCommitMsg2).toMatchInlineSnapshot('"add testFile"');
+    expect(lastCommitMsg2).toMatchInlineSnapshot('"init"');
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
-import {Option, Data, Effect, pipe, Console} from 'effect';
+import {Option, Effect, pipe, Console} from 'effect';
 import {ValidationError} from '@effect/cli';
 import {CliApp} from '@effect/cli/CliApp';
-import {isNone} from 'effect/Option';
+import {compose} from 'effect/Function';
 import * as Args from '@effect/cli/Args';
 import * as Command from '@effect/cli/Command';
 import * as Options from '@effect/cli/Options';
@@ -15,91 +15,37 @@ import {
   ticketUrlForCurrentBranch,
 } from './core';
 import * as packageJson from '../package.json';
-import {
-  GitCreateJiraBranchError,
-  matchGitCreateJiraBranchResult,
-} from './types';
-import {compose} from 'effect/Function';
+import {matchGitCreateJiraBranchResult} from './types';
 import {AppConfigService} from './app-config';
 import {GitClient} from './git-client';
 import {JiraClient} from './jira-client';
 import {openUrl} from './url-opener';
 
-interface GitCreateJiraBranch {
-  readonly jiraKey: Option.Option<string>;
-  readonly baseBranch: Option.Option<string>;
-  readonly reset: boolean;
-  readonly open: boolean;
-}
+// for version and help
+const gitJiraBranch = pipe(Command.make('git-create-jira-branch', {}));
 
-const GitCreateJiraBranch = Data.case<GitCreateJiraBranch>();
-
-const mainCommand = pipe(
+const createCommand = pipe(
   Command.make(
-    'git-create-jira-branch',
+    'create',
     {
       options: Options.all({
         baseBranch: Options.withDescription(
-          Options.optional(Options.withAlias(Options.text('baseBranch'), 'b')),
-          'Base branch to create the new branch from',
+          Options.optional(Options.withAlias(Options.text('base'), 'b')),
+          'Base revision to create the new branch from (a branch name, tag or commit SHA)',
         ),
         reset: Options.withDescription(
           Options.withAlias(Options.boolean('reset'), 'r'),
           'Reset the branch if it already exists',
         ),
-        open: Options.withDescription(
-          Options.withAlias(Options.boolean('open'), 'o'),
-          'Open the ticket for the current branch or the given ticket in the browser',
-        ),
       }),
-      args: Args.withDescription(
-        Args.atMost(Args.text({name: 'jira-key'}), 1),
+      jiraKey: Args.withDescription(
+        Args.text({name: 'jira-key'}),
         'The Jira ticket key to create a branch for (e.g. FOOX-1234)',
       ),
     },
-    (
-      args,
-    ): Effect.Effect<
-      void,
-      GitCreateJiraBranchError,
-      | AppConfigService
-      | GitClient
-      | JiraClient
-      | CommandExecutor.CommandExecutor
-    > => {
-      const command = GitCreateJiraBranch({
-        baseBranch: args.options.baseBranch,
-        reset: args.options.reset,
-        open: args.options.open,
-        jiraKey: Option.fromNullable(args.args[0]),
-      });
-
-      if (command.open) {
-        return pipe(
-          command.jiraKey,
-          Option.match({
-            onSome: (jiraKey) => ticketUrl(jiraKey),
-            onNone: () => ticketUrlForCurrentBranch(),
-          }),
-          Effect.tap((url) =>
-            Console.log(
-              `Opening ticket url '${url}' in your default browser...`,
-            ),
-          ),
-          Effect.flatMap(openUrl),
-        );
-      }
-
-      if (isNone(command.jiraKey)) {
-        return printDocs(HelpDoc.p(Span.error('No Jira Key provided')));
-      }
-
+    ({options, jiraKey}) => {
       return Effect.flatMap(
-        gitCreateJiraBranch(
-          command.jiraKey.value,
-          command.baseBranch,
-          command.reset,
-        ),
+        gitCreateJiraBranch(jiraKey, options.baseBranch, options.reset),
         compose(
           matchGitCreateJiraBranchResult({
             onCreatedBranch: (branch) =>
@@ -114,12 +60,44 @@ const mainCommand = pipe(
     },
   ),
   Command.withDescription(
-    HelpDoc.p(
-      `Fetches the given Jira ticket and creates an aproriately named branch for it.
+    `
+Fetches the given Jira ticket and creates an aproriately named branch for it.
 The branch type (bug or feat) is determined by the ticket type. The branch name
 is based on the ticket summary.`,
-    ),
   ),
+);
+
+const openCommand = pipe(
+  Command.make(
+    'open',
+    {
+      jiraKey: Args.withDescription(
+        Args.optional(Args.text({name: 'jira-key'})),
+        'The Jira ticket key to create a branch for (e.g. FOOX-1234)',
+      ),
+    },
+    ({jiraKey}) =>
+      pipe(
+        jiraKey,
+        Option.match({
+          onSome: (jiraKey) => ticketUrl(jiraKey),
+          onNone: () => ticketUrlForCurrentBranch(),
+        }),
+        Effect.tap((url) =>
+          Console.log(`Opening ticket url '${url}' in your default browser...`),
+        ),
+        Effect.flatMap(openUrl),
+      ),
+  ),
+  Command.withDescription(
+    `
+Opens the given Jira ticket in your default browser. If no ticket is given the
+jira ticket for the current branch is opened.`,
+  ),
+);
+
+const mainCommand = gitJiraBranch.pipe(
+  Command.withSubcommands([createCommand, openCommand]),
 );
 
 const cli = {
@@ -144,7 +122,9 @@ export const cliEffect = (
     cli,
   )(args).pipe(
     Effect.catchIf(ValidationError.isValidationError, (e) =>
-      printDocs(HelpDoc.p(Span.error(HelpDoc.getSpan(e.error)))),
+      ValidationError.isInvalidValue(e) // Not printed by the cli yet
+        ? printDocs(HelpDoc.p(Span.error(HelpDoc.getSpan(e.error))))
+        : Effect.succeed(undefined),
     ),
     Effect.catchAll((e) => printDocs(HelpDoc.p(Span.error(e.message)))),
   );

--- a/test/__snapshots__/cli.spec.ts.snap
+++ b/test/__snapshots__/cli.spec.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`cli > cliEffect > should create branch with single argument 1`] = `
+exports[`cli > create subcommand > should create branch with single argument 1`] = `
 [
   [
     "Successfully created branch: 'feat/FOOX-1234-description'",
@@ -8,7 +8,7 @@ exports[`cli > cliEffect > should create branch with single argument 1`] = `
 ]
 `;
 
-exports[`cli > cliEffect > should handle basebranch argument (-b) 1`] = `
+exports[`cli > create subcommand > should handle basebranch argument (-b) 1`] = `
 [
   [
     "Successfully created branch: 'feat/FOOX-1234-description'",
@@ -16,39 +16,7 @@ exports[`cli > cliEffect > should handle basebranch argument (-b) 1`] = `
 ]
 `;
 
-exports[`cli > cliEffect > should handle open option (--open) with given ticket 1`] = `
-[
-  [
-    "Opening ticket url 'https://gcjb.atlassian.net/browse/GCJB-1234' in your default browser...",
-  ],
-]
-`;
-
-exports[`cli > cliEffect > should handle open option (--open) with given ticket 2`] = `
-[
-  [
-    "https://gcjb.atlassian.net/browse/GCJB-1234",
-  ],
-]
-`;
-
-exports[`cli > cliEffect > should handle open option (--open) without ticket 1`] = `
-[
-  [
-    "Opening ticket url 'https://gcjb.atlassian.net/browse/GCJB-1234' in your default browser...",
-  ],
-]
-`;
-
-exports[`cli > cliEffect > should handle open option (--open) without ticket 2`] = `
-[
-  [
-    "https://gcjb.atlassian.net/browse/GCJB-1234",
-  ],
-]
-`;
-
-exports[`cli > cliEffect > should handle reset option (-r) 1`] = `
+exports[`cli > create subcommand > should handle reset option (-r) 1`] = `
 [
   [
     "Reset branch: 'feat/FOOX-1234-description'",
@@ -56,7 +24,7 @@ exports[`cli > cliEffect > should handle reset option (-r) 1`] = `
 ]
 `;
 
-exports[`cli > cliEffect > should inform about branch switch 1`] = `
+exports[`cli > create subcommand > should inform about branch switch 1`] = `
 [
   [
     "Switched to already existing branch: 'feat/FOOX-1234-description'",
@@ -64,13 +32,14 @@ exports[`cli > cliEffect > should inform about branch switch 1`] = `
 ]
 `;
 
-exports[`cli > cliEffect > should print help (--help) 1`] = `
+exports[`cli > create subcommand > should print subcommand help (--help) 1`] = `
 "
 [0;1mUSAGE[0m
 
-$ git-create-jira-branch [(-b, --baseBranch text)] [(-r, --reset)] [(-o, --open)] <jira-key>...
+$ create [(-b, --base text)] [(-r, --reset)] <jira-key>
 
 [0;1mDESCRIPTION[0m
+
 
 Fetches the given Jira ticket and creates an aproriately named branch for it.
 The branch type (bug or feat) is determined by the ticket type. The branch name
@@ -78,21 +47,19 @@ is based on the ticket summary.
 
 [0;1mARGUMENTS[0m
 
-[0;1m[0;30;1m<jira-key>[0;1m 0 - 1[0m
+[0;1m[0;30;1m<jira-key>[0;1m[0m
 
   A user-defined piece of text.
 
   The Jira ticket key to create a branch for (e.g. FOOX-1234)
 
-  This argument must be repeated at least 0 times and may be repeated up to 1 times.
-
 [0;1mOPTIONS[0m
 
-[0;1m(-b, --baseBranch text)[0m
+[0;1m(-b, --base text)[0m
 
   A user-defined piece of text.
 
-  Base branch to create the new branch from
+  Base revision to create the new branch from (a branch name, tag or commit SHA)
 
   This setting is optional.
 
@@ -101,14 +68,6 @@ is based on the ticket summary.
   A true or false value.
 
   Reset the branch if it already exists
-
-  This setting is optional.
-
-[0;1m(-o, --open)[0m
-
-  A true or false value.
-
-  Open the ticket for the current branch or the given ticket in the browser
 
   This setting is optional.
 
@@ -146,11 +105,154 @@ is based on the ticket summary.
 "
 `;
 
-exports[`cli > cliEffect > should report missing jirakey 1`] = `
+exports[`cli > create subcommand > should report missing jirakey 1`] = `
 [
   [
-    "[0;31mNo Jira Key provided[0m
+    "Missing argument <jira-key>
 ",
   ],
 ]
+`;
+
+exports[`cli > main command > should print help (--help) 1`] = `
+"
+[0;1mUSAGE[0m
+
+$ git-create-jira-branch
+
+[0;1mOPTIONS[0m
+
+[0;1m--completions sh | bash | fish | zsh[0m
+
+  One of the following: sh, bash, fish, zsh
+
+  Generate a completion script for a specific shell
+
+  This setting is optional.
+
+[0;1m(-h, --help)[0m
+
+  A true or false value.
+
+  Show the help documentation for a command
+
+  This setting is optional.
+
+[0;1m--wizard[0m
+
+  A true or false value.
+
+  Start wizard mode for a command
+
+  This setting is optional.
+
+[0;1m--version[0m
+
+  A true or false value.
+
+  Show the version of the application
+
+  This setting is optional.
+
+[0;1mCOMMANDS[0m
+
+  - create [(-b, --base text)] [(-r, --reset)] <jira-key>  
+Fetches the given Jira ticket and creates an aproriately named branch for it.
+The branch type (bug or feat) is determined by the ticket type. The branch name
+is based on the ticket summary.
+
+  - open [<jira-key>]                                      
+Opens the given Jira ticket in your default browser. If no ticket is given the
+jira ticket for the current branch is opened.
+"
+`;
+
+exports[`cli > open subcommand > should open url for current branch without arguments 1`] = `
+[
+  [
+    "Opening ticket url 'https://gcjb.atlassian.net/browse/GCJB-1234' in your default browser...",
+  ],
+]
+`;
+
+exports[`cli > open subcommand > should open url for current branch without arguments 2`] = `
+[
+  [
+    "https://gcjb.atlassian.net/browse/GCJB-1234",
+  ],
+]
+`;
+
+exports[`cli > open subcommand > should open url for given ticket 1`] = `
+[
+  [
+    "Opening ticket url 'https://gcjb.atlassian.net/browse/GCJB-1234' in your default browser...",
+  ],
+]
+`;
+
+exports[`cli > open subcommand > should open url for given ticket 2`] = `
+[
+  [
+    "https://gcjb.atlassian.net/browse/GCJB-1234",
+  ],
+]
+`;
+
+exports[`cli > open subcommand > should print subcommand help (--help) 1`] = `
+"
+[0;1mUSAGE[0m
+
+$ open [<jira-key>]
+
+[0;1mDESCRIPTION[0m
+
+
+Opens the given Jira ticket in your default browser. If no ticket is given the
+jira ticket for the current branch is opened.
+
+[0;1mARGUMENTS[0m
+
+[0;1m[0;30;1m<jira-key>[0;1m[0m
+
+  A user-defined piece of text.
+
+  The Jira ticket key to create a branch for (e.g. FOOX-1234)
+
+  This setting is optional.
+
+[0;1mOPTIONS[0m
+
+[0;1m--completions sh | bash | fish | zsh[0m
+
+  One of the following: sh, bash, fish, zsh
+
+  Generate a completion script for a specific shell
+
+  This setting is optional.
+
+[0;1m(-h, --help)[0m
+
+  A true or false value.
+
+  Show the help documentation for a command
+
+  This setting is optional.
+
+[0;1m--wizard[0m
+
+  A true or false value.
+
+  Start wizard mode for a command
+
+  This setting is optional.
+
+[0;1m--version[0m
+
+  A true or false value.
+
+  Show the version of the application
+
+  This setting is optional.
+"
 `;


### PR DESCRIPTION
BREAKING-CHANGE: the are 2 subcommands `open` and `create` now that must be used instead of the options `--open` and `--create` that existed before.